### PR TITLE
update default message size and document encryption methods

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -28,7 +28,7 @@ const (
 const (
 	Port               = 8080
 	Host               = "localhost"
-	DefaultMessageSize = 120
+	DefaultMessageSize = 240
 )
 
 // For kind=PGP and unset path


### PR DESCRIPTION
## Summary
- bump `DefaultMessageSize` to 240 bytes
- document Age, PGP and RSA encryption
- add detailed RSA encryption notes
- list available key-kind options
