### PR TITLE
add developer guide with diagrams

### DIFF
--- a/developer-guide.md
+++ b/developer-guide.md
@@ -1,0 +1,87 @@
+# Developer Guide
+
+Welcome to the KPow project! This document provides pointers for navigating and contributing to the codebase.
+
+## Project Layout
+
+- **cmd/** – Command line interface built with Cobra. The `start` command lives here.
+- **config/** – Configuration structs and helpers. `GetConfig` merges config files, environment variables and CLI flags.
+- **server/** – Core application code. Contains HTTP server setup, form handling, encryption helpers, mailers and cron jobs.
+- **styles/** – Tailwind CSS sources. `just styles` compiles them into the assets under `server/public/`.
+- **art/** – Images used in documentation or the web interface.
+
+## Getting Started
+
+1. **Install Go** – The project uses Go modules. Ensure you have Go 1.21+ installed.
+2. **Install Bun (optional)** – Needed to rebuild styles with `just styles`.
+3. **Run the server**
+   ```sh
+   go run main.go start
+   ```
+   CLI flags override environment variables and configuration files (see `readme.md`).
+
+## Configuration
+
+Settings can be supplied via a TOML file, environment variables, or CLI flags. See `config/config.go` for all available options. The example `config.toml` and `example.env` provide useful defaults.
+
+Key configuration topics:
+
+- **Server** – Port, host, logging and request limits.
+- **Mailers** – SMTP or webhook destinations. Failed messages are stored in an inbox folder.
+- **Encryption** – Supports `age`, `pgp`, or `rsa` public keys. Keys are loaded on start and used to encrypt form submissions.
+- **Scheduler** – A cron job retries sending failed messages from the inbox.
+
+### Configuration flow
+
+```mermaid
+flowchart TD
+    A[Start] --> B{Config File Provided?}
+    B -- Yes --> C[Load Config File]
+    B -- No --> D[Use Config Defaults]
+    C --> E[Load Environment Variables]
+    C --> D
+    D --> E
+    E --> F[Apply CLI Arguments]
+```
+
+## Development Tips
+
+- **Templates** live in `server/templates/` and define the HTML form and error pages. Update these to customize the UI.
+- **Middleware** is configured in `server/server.go` – CSRF protection, rate limiting and body limits can be adjusted there.
+- **Cron jobs** are located under `server/cron/`. The inbox cleaner periodically attempts to resend failed messages.
+- **Encryption utilities** reside in `server/enc/`. Use the tests here as references for generating keys and encrypting data.
+### Mailer retry flow
+
+```mermaid
+flowchart TD
+    A[New Message Submitted] --> B{Try to Send Immediately?}
+    B -- Success --> C[Message Sent]
+    B -- Error --> D[Save to Inbox Folder]
+    D --> E[Scheduler Run]
+    E --> F[Read Messages in Batches]
+    F --> G{Try to Re-Send}
+    G -- Success --> H[Message Sent]
+    G -- Error --> E
+```
+
+
+## Running Tests
+
+The repository contains unit tests in the `server/enc` package and for CLI configuration overrides. Run them with:
+
+```sh
+go test ./...
+```
+
+(Tests may require network access to download toolchains.)
+
+## Contributing
+
+1. Fork the repository and create a feature branch.
+2. Follow standard Go formatting (`gofmt`).
+3. Add tests for new functionality when possible.
+4. When adding a new feature or fixing a bug, tests are required.
+5. Submit a pull request describing your changes.
+
+For a deeper explanation of how the form, encryption and retry logic work, see `readme.md` and the source comments throughout the `server` package.
+


### PR DESCRIPTION
## Summary
- expand developer guide with configuration and mailer flow diagrams
- note that tests are required for features and bugfixes

## Testing
- `go fmt ./...` *(fails: unable to download Go toolchain)*
- `go test ./...` *(fails: unable to download Go toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_68531eb73134833290d504a0a0045701