### PR TITLE
add key generation instructions

### DIFF
--- a/developer-guide.md
+++ b/developer-guide.md
@@ -31,6 +31,15 @@ Key configuration topics:
 - **Encryption** – Supports `age`, `pgp`, or `rsa` public keys. Keys are loaded on start and used to encrypt form submissions.
 - **Scheduler** – A cron job retries sending failed messages from the inbox.
 
+To specify the encryption key via a config file, include a `[key]` section:
+
+```toml
+[key]
+kind = "age"           # or "pgp" or "rsa"
+path = "/etc/kpow/key.pub"
+advertise = false
+```
+
 ### Configuration flow
 
 ```mermaid
@@ -49,7 +58,34 @@ flowchart TD
 - **Templates** live in `server/templates/` and define the HTML form and error pages. Update these to customize the UI.
 - **Middleware** is configured in `server/server.go` – CSRF protection, rate limiting and body limits can be adjusted there.
 - **Cron jobs** are located under `server/cron/`. The inbox cleaner periodically attempts to resend failed messages.
-- **Encryption utilities** reside in `server/enc/`. Use the tests here as references for generating keys and encrypting data.
+- **Encryption utilities** reside in `server/enc/`. Use the tests here as references for encrypting data.
+
+### Generating Keys
+
+Use the following commands to create test keys for development:
+
+#### Age
+
+```sh
+age-keygen -o age.key
+grep "^# public key:" age.key | cut -d' ' -f3 > age.pub
+```
+
+#### PGP
+
+```sh
+gpg --quick-generate-key "Your Name <you@example.com>"
+gpg --armor --export you@example.com > pgp.pub
+```
+
+#### RSA
+
+```sh
+openssl genpkey -algorithm RSA -out rsa_private.pem -pkeyopt rsa_keygen_bits:2048
+openssl rsa -pubout -in rsa_private.pem -out rsa_public.pem
+```
+
+The `rsa_public.pem` file must contain a PKIX PEM‑encoded key.
 ### Mailer retry flow
 
 ```mermaid

--- a/readme.md
+++ b/readme.md
@@ -91,6 +91,49 @@ Provide the key kind with `--key-kind` (or `KPOW_KEY_KIND`) and the
 path to your public key with `--pubkey` (or `KPOW_KEY_PATH`).
 Available `--key-kind` options: `age`, `pgp`, or `rsa`.
 
+### Generating Keys
+
+Use common command‑line tools to create compatible public keys:
+
+#### Age
+
+```sh
+age-keygen -o age.key
+grep "^# public key:" age.key | cut -d' ' -f3 > age.pub
+```
+
+Use `age.pub` as the value for `--pubkey` (or `KPOW_KEY_PATH`).
+
+#### PGP
+
+```sh
+gpg --quick-generate-key "Your Name <you@example.com>"
+gpg --armor --export you@example.com > pgp.pub
+```
+
+Pass the ASCII-armored `pgp.pub` file to `--pubkey`.
+
+#### RSA
+
+```sh
+openssl genpkey -algorithm RSA -out rsa_private.pem -pkeyopt rsa_keygen_bits:2048
+openssl rsa -pubout -in rsa_private.pem -out rsa_public.pem
+```
+
+Provide `rsa_public.pem` as `--pubkey`. The public key must be a PKIX
+PEM‑encoded RSA key (2048 bits or greater).
+
+### Config file example
+
+Instead of CLI flags, specify the key in a TOML config file:
+
+```toml
+[key]
+kind = "age"           # or "pgp" or "rsa"
+path = "/etc/kpow/key.pub"
+advertise = false
+```
+
 ### RSA Encryption Note
 
 This system uses RSA encryption with OAEP padding and the SHA-256 hashing algorithm.


### PR DESCRIPTION
## Summary
- document config file section for specifying encryption keys
- mention key configuration snippet in developer guide
- guide on generating Age, PGP and RSA keys remains
