### PR TITLE
Move German documentation under docs/de

### DIFF
--- a/developer-guide.md
+++ b/developer-guide.md
@@ -1,7 +1,7 @@
 # Developer Guide
 
 
-[English](developer-guide.md) | [Qyrgyz](docs/qy/developer-guide.md)
+[English](developer-guide.md) | [Deutsch](docs/de/developer-guide.md) | [Qyrgyz](docs/qy/developer-guide.md)
 
 Welcome to the KPow project! This document provides pointers for navigating and contributing to the codebase.
 

--- a/docs/de/developer-guide.md
+++ b/docs/de/developer-guide.md
@@ -1,0 +1,130 @@
+# Entwicklerhandbuch
+
+[Deutsch](developer-guide.md) | [English](../../developer-guide.md) | [Qyrgyz](../qy/developer-guide.md)
+
+Dieses Dokument hilft dir, dich im KPow-Projekt zurechtzufinden und Beiträge beizusteuern.
+
+-   **cmd/** – Befehlszeilenschnittstelle auf Basis von Cobra. Hier befindet sich der Befehl `start`.
+-   **config/** – Konfigurationsstrukturen und Hilfsfunktionen. `GetConfig` führt Konfigurationsdateien, Umgebungsvariablen und CLI-Flags zusammen.
+-   **server/** – Kern der Anwendung. Enthält HTTP-Server, Formularverarbeitung, Verschlüsselung, Mailer und Cron-Dienste.
+-   **styles/** – Tailwind-CSS-Stile. `just styles` kompiliert sie.
+-   **art/** – Grafiken, die in der Dokumentation oder im Web-Interface verwendet werden.
+
+1. **Go installieren** – Das Projekt nutzt Go-Module. Installiere Go 1.21 oder höher.
+2. **Bun** – Wird für `just styles` benötigt.
+3. **Server starten**
+
+```sh
+./kpow start --config=config.yml
+```
+
+CLI-Flags überschreiben Umgebungsvariablen und Einträge in der Konfigurationsdatei.
+
+## Konfiguration
+
+Einstellungen können per TOML-Datei, Umgebungsvariablen oder CLI-Flags gesetzt werden. Eine Übersicht liefert `config/config.go`. Beispiele findest du in `config.toml` und `example.env`.
+
+-   **Server** – Port, Host, Logging und Request-Limits.
+-   **Mailer** – Versand per SMTP oder Webhook. Fehlgeschlagene Nachrichten landen im Inbox-Ordner.
+-   **Verschlüsselung** – Unterstützt öffentliche Schlüssel vom Typ `age`, `pgp` oder `rsa`.
+-   **Scheduler** – Cron-Job, der den Inbox-Ordner erneut versucht zu versenden.
+
+Beispiel zur Angabe des Schlüssels in der Konfigurationsdatei:
+
+```toml
+[key]
+kind = "age"           # oder "pgp" bzw. "rsa"
+path = "/etc/kpow/key.pub"
+advertise = false
+```
+
+### Ablauf der Konfiguration
+
+```mermaid
+flowchart TD
+    A[Start] --> B{Config-Datei vorhanden?}
+    B -- ja --> C[Konfigurationsdatei laden]
+    B -- nein --> D[Standardwerte verwenden]
+    C --> D
+    D --> E[Umgebungsvariablen laden]
+    E --> F[CLI-Parameter anwenden]
+```
+
+### Konfiguration prüfen
+
+```sh
+./kpow verify --config=config.toml
+```
+
+## Tipps für die Entwicklung
+
+-   **Templates** befinden sich unter `server/templates/` für Formulare und Fehlerseiten.
+-   **Middleware** in `server/server.go` – CSRF-Schutz, Rate-Limiting und Body-Limits.
+-   **Cron-Jobs** liegen in `server/cron/`. Versucht erneut zu senden, was im Inbox-Ordner liegt.
+-   **Verschlüsselungs-Helfer** findest du unter `server/enc/`.
+
+### Schlüssel generieren
+
+Age:
+
+```sh
+age-keygen -o age.key
+grep "^# public key:" age.key | cut -d' ' -f3 > age.pub
+```
+
+PGP:
+
+```sh
+gpg --quick-generate-key "Dein Name <du@example.com>"
+gpg --armor --export du@example.com > pgp.pub
+```
+
+RSA:
+
+```sh
+openssl genpkey -algorithm RSA -out rsa_private.pem -pkeyopt rsa_keygen_bits:2048
+openssl rsa -pubout -in rsa_private.pem -out rsa_public.pem
+```
+
+`rsa_public.pem` muss im PKIX-PEM-Format vorliegen.
+
+### Mailer-Ablauf
+
+```mermaid
+flowchart TD
+    A[Neue Nachricht] --> B{Direkt senden?}
+    B -- Ja --> C[Nachricht gesendet]
+    B -- Nein --> D[In Inbox speichern]
+    D --> E[Cron-Job starten]
+    E --> F[Nachrichten lesen]
+    F --> G{Erneut senden?}
+    G -- Ja --> H[Nachricht gesendet]
+    G -- Ja --> E
+```
+
+## Tests ausführen
+
+```sh
+go test ./...
+```
+
+(Tests benötigen ggf. Internetzugang.)
+
+## Mitwirken
+
+1. Repository forken und Feature-Branch anlegen.
+2. Mit `gofmt` formatieren.
+3. Für neue Funktionalität Tests hinzufügen.
+4. Pull-Request eröffnen.
+
+Weitere Details zu Formular, Verschlüsselung und Retry-Logik findest du in `readme.md` sowie in den Kommentaren im Paket `server`.
+
+## Releases
+
+1. `just test` ausführen.
+2. Mit `just build` oder GoReleaser bauen.
+3. Lizenzen prüfen.
+4. Sicherstellen, dass keine sensiblen Daten im Commit landen.
+5. Git-Tag setzen.
+
+Das Projekt steht unter der Business Source License 1.1 und wechselt laut README am 04.12.2028 auf die Apache License 2.0.

--- a/docs/de/readme.md
+++ b/docs/de/readme.md
@@ -1,0 +1,235 @@
+[![Test](https://github.com/sultaniman/kpow/actions/workflows/test.yml/badge.svg)](https://github.com/sultaniman/kpow/actions/workflows/test.yml)
+---
+<a href="https://coff.ee/sultaniman" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Spendiere mir einen Kaffee" height="36"></a>
+
+# KPow 💥
+
+**Sprache:** [Deutsch](readme.md) · [English](../../readme.md) · [Qyrgyz](../qy/readme.md)
+
+KPow ist ein selbst gehostetes, auf Privatsphäre ausgerichtetes Kontaktformular,
+das sichere Kommunikation ohne Drittanbieter ermöglicht.
+Es nutzt moderne Verschlüsselungsstandards wie Age, PGP und RSA,
+um eingehende Nachrichten zu verschlüsseln und zu schützen.
+
+Ideal für datenschutzbewusste Organisationen, Open-Source-Projekte und unabhängige Seiten.
+
+## Server starten
+
+### Über CLI-Parameter
+
+```sh
+$ kpow start \
+  --config=/etc/kpow/config.toml \
+  --port=8080 \
+  --host=0.0.0.0 \
+  --limiter-rpm=100 \
+  --limiter-burst=20 \
+  --limiter-cooldown=10 \
+  --mailer-from=sender@example.com \
+  --mailer-to=recipient@example.com \
+  --mailer-dsn=smtp://user:password@smtp.example.com:587 \
+  --max-retries=3 \
+  --webhook-url=https://hooks.example.com/notify \
+  --pubkey=/keys/key.pub \
+  --key-kind=rsa \
+  --advertise-key \
+  --inbox-path=/data/inbox \
+  --inbox-cron="*/5 * * * *" \
+  --log-level=INFO \
+  --banner=/etc/kpow/banner.html \
+  --hide-logo \
+  --message-size=512
+```
+
+### Nutzung einer Konfigurationsdatei
+
+> [!note]
+> CLI-Flags haben immer Vorrang; setze sie bewusst ein.
+
+Die Reihenfolge der Konfiguration:
+
+1. Konfigurationsdatei laden
+2. Umgebungsvariablen anwenden (ENV)
+3. CLI-Parameter überschreiben die vorherigen Werte
+
+```mermaid
+flowchart TD
+    A[Start] --> B{Config-Datei vorhanden?}
+    B -- ja --> C[Konfigurationsdatei laden]
+    B -- nein --> D[Standardwerte verwenden]
+    C --> D
+    D --> E[Umgebungsvariablen laden]
+    E --> F[CLI-Parameter anwenden]
+```
+
+```sh
+$ kpow start --config=path-to-config.toml
+```
+
+### Konfigurationsdatei prüfen
+
+Überprüfe die Konfiguration vor dem Start des Servers:
+
+```sh
+$ kpow verify --config=path-to-config.toml
+```
+
+### Umgebungsvariablen
+
+| Variable                | Beschreibung                      | Typ    | Standardwert    |
+| ----------------------- | --------------------------------- | ------ | --------------- |
+| `KPOW_TITLE`            | Anzeigename des Servers           | string | ""              |
+| `KPOW_PORT`             | Server-Port                       | int    | 8080            |
+| `KPOW_HOST`             | Host-Adresse                      | string | localhost       |
+| `KPOW_LOG_LEVEL`        | Log-Level                         | string | INFO            |
+| `KPOW_MESSAGE_SIZE`     | Maximale Nachrichtengröße         | int    | 240             |
+| `KPOW_HIDE_LOGO`        | Logo ausblenden                   | bool   | false           |
+| `KPOW_CUSTOM_BANNER`    | Pfad zur Banner-Datei             | string | ""              |
+| `KPOW_LIMITER_RPM`      | Requests pro Minute               | int    | 0               |
+| `KPOW_LIMITER_BURST`    | Burst-Anzahl                      | int    | -1              |
+| `KPOW_LIMITER_COOLDOWN` | Cooldown für Rate-Limit           | int    | -1              |
+| `KPOW_MAILER_FROM`      | Absenderadresse                   | string | ""              |
+| `KPOW_MAILER_TO`        | Empfängeradresse                  | string | ""              |
+| `KPOW_MAILER_DSN`       | SMTP-DSN                          | string | ""              |
+| `KPOW_WEBHOOK_URL`      | Webhook-URL                       | string | ""              |
+| `KPOW_MAX_RETRIES`      | Anzahl der Wiederholungsversuche  | int    | 2               |
+| `KPOW_KEY_KIND`         | Schlüsseltyp: `age`, `pgp`, `rsa` | string | ""              |
+| `KPOW_ADVERTISE`        | Schlüssel bekannt machen?         | bool   | false           |
+| `KPOW_KEY_PATH`         | Pfad zur Schlüsseldatei           | string | ""              |
+| `KPOW_INBOX_PATH`       | Pfad zum Inbox-Ordner             | string | ""              |
+| `KPOW_INBOX_CRON`       | Cron-Zeitplan für die Inbox       | string | `*/5 * * * *`   |
+
+> [!note]
+> Für den Versand benötigt KPow entweder `KPOW_MAILER_DSN` oder `KPOW_WEBHOOK_URL`.
+
+## Verschlüsselung
+
+KPow nutzt öffentliche Schlüssel für Age, PGP und RSA,
+um eingehende Nachrichten asymmetrisch zu verschlüsseln.
+Gib den Typ mit `--key-kind` (bzw. `KPOW_KEY_KIND`) und den Pfad mit
+`--pubkey` (bzw. `KPOW_KEY_PATH`) an.
+Mögliche Werte: `age`, `pgp`, `rsa`.
+
+### Schlüssel erzeugen
+
+Per CLI:
+
+#### Age
+
+```sh
+age-keygen -o age.key
+grep "^# public key:" age.key | cut -d' ' -f3 > age.pub
+```
+
+Verwende `age.pub` mit `--pubkey`.
+
+#### PGP
+
+```sh
+gpg --quick-generate-key "Dein Name <du@example.com>"
+gpg --armor --export du@example.com > pgp.pub
+```
+
+`pgp.pub` anschließend mit `--pubkey` angeben.
+
+#### RSA
+
+```sh
+openssl genpkey -algorithm RSA -out rsa_private.pem -pkeyopt rsa_keygen_bits:2048
+openssl rsa -pubout -in rsa_private.pem -out rsa_public.pem
+```
+
+`rsa_public.pem` bei `--pubkey` nutzen. Der Schlüssel muss im PKIX-PEM-Format vorliegen.
+
+### Beispielkonfiguration
+
+Statt CLI-Flags kannst du den Schlüssel in der TOML-Datei definieren:
+
+```toml
+[key]
+kind = "age"           # oder "pgp" bzw. "rsa"
+path = "/etc/kpow/key.pub"
+advertise = false
+```
+
+### RSA-Verschlüsselung
+
+KPow verwendet RSA OAEP mit SHA-256. Die maximale Nachrichtengröße hängt
+dabei von der Schlüssellänge ab. Bei einem 2048-Bit-Schlüssel empfiehlt
+sich `message_size = 180`.
+
+## Mailer-Ablauf
+
+```mermaid
+flowchart TD
+    A[Neue Nachricht] --> B{Direkt senden?}
+    B -- Ja --> C[Nachricht gesendet]
+    B -- Nein --> D[In Inbox speichern]
+    D --> E[Cron-Job starten]
+    E --> F[Nachrichten lesen]
+    F --> G{Erneut senden?}
+    G -- Ja --> H[Nachricht gesendet]
+    G -- Ja --> E
+```
+
+## Webhook
+
+Mit `--webhook-url` (oder `KPOW_WEBHOOK_URL`) sendet KPow die
+verschlüsselte Nachricht als JSON per POST an das Ziel:
+
+```json
+{
+    "subject": "<form subject>",
+    "content": "<encrypted message>",
+    "hash": "<sha256-hash>"
+}
+```
+
+Die URL muss HTTPS verwenden, außer bei `localhost`.
+Antworten mit Status < 400 gelten als erfolgreich.
+
+## Entwicklung
+
+### Formular anpassen
+
+Zur Erstellung der Styles kommen Bun und Tailwind CSS zum Einsatz.
+
+- Styles liegen im Ordner `styles`.
+- `just styles` baut die regulären Styles.
+- `just error-styles` erzeugt die Fehlerseiten-Styles.
+
+Für diese Befehle werden `bun` und `bunx` benötigt.
+
+### Banner anpassen
+
+Mit `--banner=/path/to/banner.html` oder
+`KPOW_CUSTOM_BANNER=/path/to/banner.html` kannst du dein eigenes Banner einbinden.
+Der HTML-Inhalt wird gesäubert; folgende Tags sind erlaubt:
+
+- `a`
+- `p`
+- `span`
+- `img`
+- `div`
+- `ul,ol,li`
+- `h1-h6`
+
+## Lizenz
+
+KPow steht unter der **Business Source License 1.1**.
+Das Hosting als Drittanbieterdienst ist ohne zusätzliche Lizenz nicht gestattet.
+Am **04.12.2028** wechselt das Projekt automatisch zur **Apache License 2.0**.
+
+- 📄 [`LICENSE`](./LICENSE)
+- 📄 [`LICENSE-BUSL`](./LICENSE-BUSL)
+- 📄 [`LICENSE-APACHE`](./LICENSE-APACHE)
+
+## Screenshots
+
+![form](https://github.com/sultaniman/kpow/blob/main/screenshots/form.png?raw=true)
+---
+![rate limited](https://github.com/sultaniman/kpow/blob/main/screenshots/rate-limited.png?raw=true)
+---
+![csrf error](https://github.com/sultaniman/kpow/blob/main/screenshots/csrf-error.png?raw=true)
+
+<p align="center">✨ 🚀 ✨</p>

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@
 
 
 
-[English](readme.md) | [Qyrgyz](docs/qy/readme.md)
+[English](readme.md) | [Deutsch](docs/de/readme.md) | [Qyrgyz](docs/qy/readme.md)
 
 KPow is a self-hosted, privacy-focused contact form designed for secure communication without relying on third-party services.
 It supports modern encryption standards — PGP, Age, and RSA — to ensure that messages are encrypted before delivery.


### PR DESCRIPTION
## Summary
- add German versions of the developer guide and README under docs/de while keeping the English docs as the primary references
- restore the Kyrgyz docs in docs/qy and update language navigation links to include the new German translations

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d67d5df690833295d63e0f7c642714